### PR TITLE
add pre-commit linter conf

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,44 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.1.0
+  hooks:
+  -   id: trailing-whitespace
+  -   id: end-of-file-fixer
+  -   id: check-added-large-files
+- repo: https://github.com/asottile/pyupgrade
+  rev: v2.31.0
+  hooks:
+    - id: pyupgrade
+      args: ["--py37-plus"]
+- repo: https://github.com/pycqa/isort
+  rev: 5.10.1
+  hooks:
+    - id: isort
+      name: isort (python)
+      args:
+      - --profile=black
+      - --line-length=120
+- repo: https://github.com/psf/black
+  rev: 22.1.0
+  hooks:
+    - id: black
+      args:
+      - --line-length=120
+      - --target-version=py310
+- repo: https://github.com/PyCQA/flake8
+  rev: 4.0.1
+  hooks:
+    - id: flake8
+      additional_dependencies:
+        - flake8-bugbear
+        - flake8-implicit-str-concat
+        - flake8-annotations
+      args: ["--max-line-length=120","--ignore=ANN204,ANN101,ANN102,ANN002,ANN003,E203,W503"]
+      # ignore errors
+      # -ANN204: "Missing return type annotation for special method"
+      # -ANN101: "Missing type annotation for self in method"
+      # -ANN102 "Missing type annotation for cls in classmethod"
+      # -ANN002 "Missing type annotation for *args"
+      # -ANN003 "Missing type annotation for *kwargs"
+      # -W503 "Line break occurred before a binary operator" See https://www.flake8rules.com/rules/W503.html
+      # -E203:  whitespace before ':' because pep8 is wrong here. See https://github.com/psf/black/issues/315


### PR DESCRIPTION
Hello !
This is a proposal for the styling of the code, especially the python part.
pre-commit is a tool that allow a user (or a build pipeline) to automatically run several linters on the code. For now pre-commit is configured only for python linter, but maybe at some point you will wish to have also a c/cpp linter.
(pre-commit is used is some big projects like https://github.com/pallets/flask)
I will do a second PR with the result of `pre-commit run -a` command, so you can see what it does

Edit: the result of pre-commit is https://github.com/cooklang/cooklang-c/pull/9