### PR TITLE
Change parsing to strings not files

### DIFF
--- a/include/CooklangParser.h
+++ b/include/CooklangParser.h
@@ -10,6 +10,7 @@
 
 // wrappers
 Recipe * parseRecipe( char * fileName );
+Recipe * parseRecipeString( char * inputRecipeString );
 
 
 // others

--- a/src/CooklangExtension.c
+++ b/src/CooklangExtension.c
@@ -222,7 +222,7 @@ static PyObject * methodPrintRecipe(PyObject * self, PyObject * args){
 static PyObject * methodParseRecipe(PyObject *self, PyObject * args){
   int check;
   int dirLength;
-  char * fileName = NULL;
+  char * recipeString;
 
   ListIterator stepIter;
   Step * curStep;
@@ -242,12 +242,12 @@ static PyObject * methodParseRecipe(PyObject *self, PyObject * args){
 
 
   // get args - no embedded null code points
-  if(!PyArg_ParseTuple(args, "s", &fileName)){
+  if(!PyArg_ParseTuple(args, "s", &recipeString)){
     return NULL;
   }
 
   // parse the recipe recipe
-  Recipe * parsedRecipe = parseRecipe(fileName);
+  Recipe * parsedRecipe = parseRecipeString(recipeString);
 
   // build a python object to represent the recipe
   PyObject * recipeObject = PyDict_New();
@@ -284,7 +284,7 @@ static PyObject * methodParseRecipe(PyObject *self, PyObject * args){
 
 
 
-  // add all the steps
+  // add all the steps/ingredients/cookware
 
   // the lists to store steps/ingredients/cookware
   stepListObject = PyList_New(0);

--- a/src/CooklangParser.c
+++ b/src/CooklangParser.c
@@ -7,9 +7,39 @@
 
 
 extern FILE * yyin;
-
+typedef struct yy_buffer_state * YY_BUFFER_STATE;
+extern YY_BUFFER_STATE yy_scan_string(char * str);
+extern void yy_delete_buffer(YY_BUFFER_STATE buffer);
 
 // wrapper functions
+// this function will parse the recipe from a string
+Recipe * parseRecipeString( char * inputRecipeString ){
+
+  // setup the recipe
+  Recipe * finalRecipe = createRecipe();
+
+  // create the first step
+  Step * currentStep = createStep();
+  insertBack(finalRecipe->stepList, currentStep);
+  printf("here2\n");
+
+  // add a newline at the end of the string to prevent errors in the parser
+  char * newInputString = malloc(sizeof(char) * (strlen(inputRecipeString) + 20));
+  sprintf(newInputString, "%s\n", inputRecipeString);
+
+  // feed input to lexer
+  YY_BUFFER_STATE buffer = yy_scan_string(newInputString);
+  // parser
+  yyparse(finalRecipe);
+  yy_delete_buffer(buffer);
+
+  printf("here3\n");
+
+
+  return finalRecipe;
+}
+
+
 Recipe * parseRecipe( char * fileName ){
 
   FILE * file;

--- a/src/CooklangParser.c
+++ b/src/CooklangParser.c
@@ -21,7 +21,6 @@ Recipe * parseRecipeString( char * inputRecipeString ){
   // create the first step
   Step * currentStep = createStep();
   insertBack(finalRecipe->stepList, currentStep);
-  printf("here2\n");
 
   // add a newline at the end of the string to prevent errors in the parser
   char * newInputString = malloc(sizeof(char) * (strlen(inputRecipeString) + 20));
@@ -32,9 +31,6 @@ Recipe * parseRecipeString( char * inputRecipeString ){
   // parser
   yyparse(finalRecipe);
   yy_delete_buffer(buffer);
-
-  printf("here3\n");
-
 
   return finalRecipe;
 }

--- a/testing/testing.py
+++ b/testing/testing.py
@@ -122,10 +122,7 @@ def equal_inputs(expected_input: Dict, actual_input: Dict) -> bool:
 
 
 def test_parsing(file_content: str, expected_result: Dict) -> Tuple[bool, Dict]:
-    with tempfile.NamedTemporaryFile() as test_file:
-        test_file.write(file_content.encode())
-        test_file.seek(0)
-        actual_result = cooklang.parseRecipe(test_file.name)
+    actual_result = cooklang.parseRecipe(file_content)
     return equal_inputs(expected_result, actual_result), actual_result
 
 
@@ -204,6 +201,7 @@ class TestCanonical(unittest.TestCase):
         for test in tests_input["tests"]:
             expected_result = tests_input["tests"][test]["result"]
             r, actual_result = test_parsing(tests_input["tests"][test]["source"], expected_result)
+
             if r:
                 passed += 1
             else:
@@ -216,7 +214,7 @@ class TestCanonical(unittest.TestCase):
                 print("____           Compare Results           ____")
                 unpassed.append(test)
             total += 1
-
+        
         print("\n\nTests passed: " + str(passed) + "/" + str(total))
         self.assertEqual(unpassed, [])
 


### PR DESCRIPTION
Made the parseRecipeString() in C and changed the python module to use this function instead of the parseRecipe C function that takes input from a file. Then updated the testing script so that the changes to input format were reflected and testing could work again.