### PR TITLE
Better unit tests

### DIFF
--- a/testing/testing.py
+++ b/testing/testing.py
@@ -4,6 +4,7 @@ from typing import Dict, Tuple
 import cooklang
 import yaml
 
+from .testing_comment import TestComment  # noqa
 from .testing_metadata import TestMetadata  # noqa
 from .testing_number import TestNumber  # noqa
 from .testing_words import TestWords  # noqa

--- a/testing/testing.py
+++ b/testing/testing.py
@@ -6,6 +6,7 @@ import yaml
 
 from .testing_metadata import TestMetadata  # noqa
 from .testing_number import TestNumber  # noqa
+from .testing_words import TestWords  # noqa
 
 POSSIBLE_FIELDS = {
     "type",

--- a/testing/testing.py
+++ b/testing/testing.py
@@ -4,6 +4,9 @@ from typing import Dict, Tuple
 import cooklang
 import yaml
 
+from .testing_metadata import TestMetadata  # noqa
+from .testing_number import TestNumber  # noqa
+
 POSSIBLE_FIELDS = {
     "type",
     "name",

--- a/testing/testing_comment.py
+++ b/testing/testing_comment.py
@@ -7,6 +7,7 @@ class TestComment(unittest.TestCase):
     def validate(self, test_cases: list) -> None:
         for test_case in test_cases:
             output = cooklang.parseRecipe(test_case["input"])
+            print(output)
             self.assertEqual(output["steps"][0][0]["value"], test_case["output_steps"])
 
     def test_basic(self) -> None:
@@ -28,3 +29,15 @@ class TestComment(unittest.TestCase):
         ]
 
         self.validate(test_cases)
+
+    def test_multiline(self) -> None:
+        test_cases = [
+            {
+                "input": "meal for 4 people [- scale linearly  \n for people \n but time does not scale-]",
+                "output_steps": "meal for 4 people ",
+            },
+        ]
+        for test_case in test_cases:
+            output = cooklang.parseRecipe(test_case["input"])
+            print(output)
+            self.assertEqual(len(output["steps"]), 1)

--- a/testing/testing_comment.py
+++ b/testing/testing_comment.py
@@ -1,0 +1,30 @@
+import unittest
+
+import cooklang
+
+
+class TestComment(unittest.TestCase):
+    def validate(self, test_cases: list) -> None:
+        for test_case in test_cases:
+            output = cooklang.parseRecipe(test_case["input"])
+            self.assertEqual(output["steps"][0][0]["value"], test_case["output_steps"])
+
+    def test_basic(self) -> None:
+        test_cases = [
+            {
+                "input": "meal for 4 people [- scale linearly-]",
+                "output_steps": "meal for 4 people ",
+            },
+        ]
+
+        self.validate(test_cases)
+
+    def test_close_twice(self) -> None:
+        test_cases = [
+            {
+                "input": "meal for 4 people [- scale linearly -] and take 20 minutes to prepare [- does not scale-]",
+                "output_steps": "meal for 4 people  and take 20 minutes to prepare ",
+            },
+        ]
+
+        self.validate(test_cases)

--- a/testing/testing_metadata.py
+++ b/testing/testing_metadata.py
@@ -1,0 +1,21 @@
+import unittest
+
+import cooklang
+
+
+class TestMetadata(unittest.TestCase):
+    def test_basic(self) -> None:
+        test_cases = [
+            {
+                "input": ">> sourced: babooshka\n",
+                "output_metadata": {"sourced": "babooshka"},
+            },
+            {
+                "input": ">> source: https://www.gimmesomeoven.com/baked-potato/\n",
+                "output_metadata": {"source": "https://www.gimmesomeoven.com/baked-potato/"},
+            },
+        ]
+
+        for test_case in test_cases:
+            output = cooklang.parseRecipe(test_case["input"])
+            self.assertEqual(output["metadata"], test_case["output_metadata"])

--- a/testing/testing_number.py
+++ b/testing/testing_number.py
@@ -1,0 +1,26 @@
+import unittest
+
+import cooklang
+
+
+class TestNumber(unittest.TestCase):
+    def test_basic(self) -> None:
+        test_cases = [
+            {
+                "input": "@thyme{20000%springs}\n",
+                "output_ingredient_q": "20000.000",
+            },
+            {
+                "input": "@thyme{2 000%springs}\n",
+                "output_ingredient_q": "2 000",
+            },
+            {
+                "input": "@thyme{20 000%springs}\n",
+                "output_ingredient_q": "20 000",
+            },
+        ]
+
+        for test_case in test_cases:
+            output = cooklang.parseRecipe(test_case["input"])
+            print(output)
+            self.assertEqual(output["ingredients"][0]["quantity"], test_case["output_ingredient_q"])

--- a/testing/testing_words.py
+++ b/testing/testing_words.py
@@ -15,6 +15,10 @@ class TestWords(unittest.TestCase):
                 "output_steps": "recette de cm ",
             },
             {
+                "input": "recette de croque->monsieur\n",
+                "output_steps": "recette de croque->monsieur",
+            },
+            {
                 "input": "recette de [croque]-monsieur\n",
                 "output_steps": "recette de [croque]-monsieur",
             },

--- a/testing/testing_words.py
+++ b/testing/testing_words.py
@@ -1,0 +1,25 @@
+import unittest
+
+import cooklang
+
+
+class TestWords(unittest.TestCase):
+    def test_basic(self) -> None:
+        test_cases = [
+            {
+                "input": "recette de croque-monsieur",
+                "output_steps": "recette de croque-monsieur",
+            },
+            {
+                "input": "recette de cm -- croque-monsieur\n",
+                "output_steps": "recette de cm ",
+            },
+            {
+                "input": "recette de [croque]-monsieur\n",
+                "output_steps": "recette de [croque]-monsieur",
+            },
+        ]
+
+        for test_case in test_cases:
+            output = cooklang.parseRecipe(test_case["input"])
+            self.assertEqual(output["steps"][0][0]["value"], test_case["output_steps"])

--- a/testing/testing_words.py
+++ b/testing/testing_words.py
@@ -27,3 +27,15 @@ class TestWords(unittest.TestCase):
         for test_case in test_cases:
             output = cooklang.parseRecipe(test_case["input"])
             self.assertEqual(output["steps"][0][0]["value"], test_case["output_steps"])
+
+    def test_unicode(self) -> None:
+        test_cases = [
+            {
+                "input": "recette française 😃",
+                "output_steps": "recette française 😃",
+            },
+        ]
+        for test_case in test_cases:
+            output = cooklang.parseRecipe(test_case["input"])
+            print(output)
+            self.assertEqual(output["steps"][0][0]["value"], test_case["output_steps"])


### PR DESCRIPTION
Hello !

When using the parser I found some bugs.
For now I wrote the failing corresponding unit-tests. The goal of this branch is to track the evolution of these tests and to be merged when they will all succeed.

Some of these bugs need correction in the lex/bison part, but other "issues" comes from the language definition and will (maybe) require to update the EBNF https://github.com/cooklang/spec/blob/main/EBNF.md

## Regarding metadata:
* users can't write stuff like `>> source: https://www.gimmesomeoven.com/baked-potato/`. Indeed according to the EBNF, the second ":" is not a valid char. I think we should allow it (and also other cooklang char)

## Regarding number:
* as discussed in https://github.com/cooklang/cooklang-c/issues/19, parsing `@thyme{20 000%springs}` gives a quantity of 20. The multi-word should be correctly detected.

## Regarding words:
* `recette de [croque]-monsieur` is parsed as `recette de `. I think [ should be allowed if not followed by "-" OR an error should be raise if we want "[" to be a forbidden char
* `recette de croque->monsieur`is parsed as `recette de croque-monsieur`. The > should be an authorized char if not followed by another > OR an error should be raised. Here the behavior of removing the char is very weird

## Regarding comments:
* `meal for 4 people [- scale linearly -] and take 20 minutes to prepare [- does not scale-]` is parsed as `meal for 4 people`. The text between the 2 comments are not parsed. This is also an error in the EBNF : it shouldn't be `"[", "-", ? any character ?, "-", "]"` but `"[", "-", ? any character except "-" followed by "]" ?, "-", "]"`
* block comments can't be multi-line